### PR TITLE
Use DRF get_object instead of get_object_or_404

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/rest/image.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/{{ cookiecutter.first_app_name }}/rest/image.py
@@ -1,5 +1,4 @@
 from django.http import HttpResponseRedirect
-from django.shortcuts import get_object_or_404
 from django_filters import rest_framework as filters
 from rest_framework import serializers, status
 from rest_framework.decorators import action
@@ -35,12 +34,12 @@ class ImageViewSet(ReadOnlyModelViewSet):
 
     @action(detail=True, methods=['get'])
     def download(self, request, pk=None):
-        image = get_object_or_404(Image, pk=pk)
+        image = self.get_object()
         return HttpResponseRedirect(image.blob.url)
 
     @action(detail=True, methods=['post'])
     def compute(self, request, pk=None):
         # Ensure that the image exists, so a non-existent pk isn't dispatched
-        image = get_object_or_404(Image, pk=pk)
+        image = self.get_object()
         image_compute_checksum.delay(image.pk)
         return Response('', status=status.HTTP_202_ACCEPTED)


### PR DESCRIPTION
`get_object` does permission checks, `get_object_or_404` does not.