### PR TITLE
Update minio ports

### DIFF
--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -17,9 +17,10 @@ services:
     image: minio/minio:latest
     # When run with a TTY, minio prints credentials on startup
     tty: true
-    command: ["server", "/data"]
+    command: ["server", "/data", "--console-address", ":9001"]
     environment:
       MINIO_ACCESS_KEY: minioAccessKey
       MINIO_SECRET_KEY: minioSecretKey
     ports:
       - ${DOCKER_MINIO_PORT-9000}:9000
+      - 9001:9001


### PR DESCRIPTION
I'm not sure when or why, but it appears that `--console-address` is now a required argument for minio.

Without this and using the latest `minio` image, you are unable to view the web client.

Note that going to port `9000` will forward you to port `9001`. Should we adjust this so the web client is back on port `9000`?

cc @AlmightyYakob 