### PR TITLE
Use python -m when invoking celery natively

### DIFF
--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -42,7 +42,7 @@ but allows developers to run Python code on their native system.
    2. `./manage.py runserver`
 3. Run in a separate terminal:
    1. `source ./dev/export-env.sh`
-   2. `celery --app {{ cookiecutter.pkg_name }}.celery worker --loglevel INFO --without-heartbeat`
+   2. `python -m celery --app {{ cookiecutter.pkg_name }}.celery worker --loglevel INFO --without-heartbeat`
 4. When finished, run `docker-compose stop`
 
 ## Remap Service Ports (optional)


### PR DESCRIPTION
Due to how pip satisfies installation requirements, there's an unintended consequence of simply running `celery` in a virtualenv.

If you already have celery installed natively (i.e. it's present in your PATH), then when you run `pip install -e .[dev]`, even though `celery` is listed as a dependency in `setup.py`, it will not be installed, since it sees the requirement as satisfied, and there are no version constraints in `setup.py`. If you then run the current celery command, it will run the existing `celery` in your PATH, with whatever python the existing `celery` executable was installed with.

This PR simply changes the provided command to invoke celery using the `python -m` method, ensuring the python being used is the one provided by the virtualenv.

Another approach to this is to update the `pip install` command to include the `--ignore-installed` flag, which would install any dependencies that are needed, even if they do already exist somewhere else. That solution actually feels more "complete" to me, but I'm not sure of the consequences.