### PR TITLE
Expose port for RabbitMQ management console

### DIFF
--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     image: rabbitmq:management
     ports:
       - ${DOCKER_RABBITMQ_PORT-5672}:5672
+      - ${DOCKER_RABBITMQ_CONSOLE_PORT-15672}:15672
 
   minio:
     image: minio/minio:latest


### PR DESCRIPTION
The RabbitMQ Docker image that the cookiecutter uses comes with the [RabbitMQ Management Plugin](https://www.rabbitmq.com/management.html) installed, but our docker-compose config doesn't expose the port for the browser interface.