### PR TITLE
Add `default_branch` option to handle GitHub's default `main` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - ${{ github.event.repository.default_branch }}
+      - master
   schedule:
     - cron: "0 0 * * *"
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - ${{ github.event.repository.default_branch }}
   schedule:
     - cron: "0 0 * * *"
 jobs:

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,5 +4,6 @@
   "pkg_name": "{{ cookiecutter.project_slug.replace('-', '_') }}",
   "first_app_name": "core",
   "site_domain": "{{ cookiecutter.project_slug }}.test",
+  "default_branch": "main",
   "include_example_code": ["yes", "no"]
 }

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
   schedule:
     - cron: "0 0 * * *"
 jobs:

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - ${{ github.event.repository.default_branch }}
   schedule:
     - cron: "0 0 * * *"
 jobs:

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - ${{ github.event.repository.default_branch }}
+      - {{ cookiecutter.default_branch }}
   schedule:
     - cron: "0 0 * * *"
 jobs:


### PR DESCRIPTION
The default base branch for GitHub is now `main` and the cookiecutter's workflow should reflect that.