### PR TITLE
GitHub Workflow to publish development docker images to ghcr.io

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -4,5 +4,6 @@
   "pkg_name": "{{ cookiecutter.project_slug.replace('-', '_') }}",
   "first_app_name": "core",
   "site_domain": "{{ cookiecutter.project_slug }}.test",
+  "github_repo": "girder/{{ cookiecutter.project_slug }}",
   "include_example_code": ["yes", "no"]
 }

--- a/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on:
   pull_request:
   push:
     branches:
-      - master
+      - main
   schedule:
     - cron: "0 0 * * *"
 jobs:

--- a/{{ cookiecutter.project_slug }}/.github/workflows/docker-package.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/docker-package.yml
@@ -13,6 +13,7 @@ env:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
+    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository )
     strategy:
       fail-fast: false
       matrix:
@@ -35,6 +36,6 @@ jobs:
         with:
           context: .
           file: dev/{{ ${{ matrix.docker-file }} }}.Dockerfile
-          push: {{ ${{ github.event.pull_request.head.repo.full_name == github.repository }} }}
+          push: true
           tags: {{ ${{ steps.meta.outputs.tags }} }}
           labels: {{ ${{ steps.meta.outputs.labels }} }}

--- a/{{ cookiecutter.project_slug }}/.github/workflows/docker-package.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/docker-package.yml
@@ -1,0 +1,40 @@
+name: Docker Package
+on:
+  push:
+    tags: "*"
+    branches:
+      - main
+  pull_request:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        docker-file: [django, ]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Log into the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata for the Docker image
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.docker-file }}
+      - name: Build and push the Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: dev/${{ matrix.docker-file }}.Dockerfile
+          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/{{ cookiecutter.project_slug }}/.github/workflows/docker-package.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/docker-package.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 env:
   REGISTRY: ghcr.io
@@ -13,7 +14,7 @@ env:
 jobs:
   build-and-publish:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository )
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository )
     strategy:
       fail-fast: false
       matrix:

--- a/{{ cookiecutter.project_slug }}/.github/workflows/docker-package.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/docker-package.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: ${{ {{ github.repository }} }}
 
 jobs:
   build-and-publish:
@@ -22,19 +22,19 @@ jobs:
       - name: Log into the Container registry
         uses: docker/login-action@v1
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: ${{ {{ env.REGISTRY }} }}
+          username: ${{ {{ github.actor }} }}
+          password: ${{ {{ secrets.GITHUB_TOKEN }} }}
       - name: Extract metadata for the Docker image
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}/${{ matrix.docker-file }}
+          images: ${{ {{ env.REGISTRY }} }}/${{ {{ env.IMAGE_NAME }} }}/${{ {{ matrix.docker-file }} }}
       - name: Build and push the Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: dev/${{ matrix.docker-file }}.Dockerfile
-          push: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          file: dev/${{ {{ matrix.docker-file }} }}.Dockerfile
+          push: ${{ {{ github.event.pull_request.head.repo.full_name == github.repository }} }}
+          tags: ${{ {{ steps.meta.outputs.tags }} }}
+          labels: ${{ {{ steps.meta.outputs.labels }} }}

--- a/{{ cookiecutter.project_slug }}/.github/workflows/docker-package.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/docker-package.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ {{ github.repository }} }}
+  IMAGE_NAME: {{ ${{ github.repository }} }}
 
 jobs:
   build-and-publish:
@@ -22,19 +22,19 @@ jobs:
       - name: Log into the Container registry
         uses: docker/login-action@v1
         with:
-          registry: ${{ {{ env.REGISTRY }} }}
-          username: ${{ {{ github.actor }} }}
-          password: ${{ {{ secrets.GITHUB_TOKEN }} }}
+          registry: {{ ${{ env.REGISTRY }} }}
+          username: {{ ${{ github.actor }} }}
+          password: {{ ${{ secrets.GITHUB_TOKEN }} }}
       - name: Extract metadata for the Docker image
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: ${{ {{ env.REGISTRY }} }}/${{ {{ env.IMAGE_NAME }} }}/${{ {{ matrix.docker-file }} }}
+          images: {{ ${{ env.REGISTRY }} }}/{{ ${{ env.IMAGE_NAME }} }}/{{ ${{ matrix.docker-file }} }}
       - name: Build and push the Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: dev/${{ {{ matrix.docker-file }} }}.Dockerfile
-          push: ${{ {{ github.event.pull_request.head.repo.full_name == github.repository }} }}
-          tags: ${{ {{ steps.meta.outputs.tags }} }}
-          labels: ${{ {{ steps.meta.outputs.labels }} }}
+          file: dev/{{ ${{ matrix.docker-file }} }}.Dockerfile
+          push: {{ ${{ github.event.pull_request.head.repo.full_name == github.repository }} }}
+          tags: {{ ${{ steps.meta.outputs.tags }} }}
+          labels: {{ ${{ steps.meta.outputs.labels }} }}

--- a/{{ cookiecutter.project_slug }}/.github/workflows/docker-package.yml
+++ b/{{ cookiecutter.project_slug }}/.github/workflows/docker-package.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: {{ ${{ github.repository }} }}
+  IMAGE_NAME: {{ '${{ github.repository }}' }}
 
 jobs:
   build-and-publish:
@@ -23,19 +23,19 @@ jobs:
       - name: Log into the Container registry
         uses: docker/login-action@v1
         with:
-          registry: {{ ${{ env.REGISTRY }} }}
-          username: {{ ${{ github.actor }} }}
-          password: {{ ${{ secrets.GITHUB_TOKEN }} }}
+          registry: {{ '${{ env.REGISTRY }}' }}
+          username: {{ '${{ github.actor }}' }}
+          password: {{ '${{ secrets.GITHUB_TOKEN }}' }}
       - name: Extract metadata for the Docker image
         id: meta
         uses: docker/metadata-action@v3
         with:
-          images: {{ ${{ env.REGISTRY }} }}/{{ ${{ env.IMAGE_NAME }} }}/{{ ${{ matrix.docker-file }} }}
+          images: {{ '${{ env.REGISTRY }}' }}/{{ '${{ env.IMAGE_NAME }}' }}/{{ '${{ matrix.docker-file }}' }}
       - name: Build and push the Docker image
         uses: docker/build-push-action@v2
         with:
           context: .
-          file: dev/{{ ${{ matrix.docker-file }} }}.Dockerfile
+          file: dev/{{ '${{ matrix.docker-file }}' }}.Dockerfile
           push: true
-          tags: {{ ${{ steps.meta.outputs.tags }} }}
-          labels: {{ ${{ steps.meta.outputs.labels }} }}
+          tags: {{ '${{ steps.meta.outputs.tags }}' }}
+          labels: {{ '${{ steps.meta.outputs.labels }}' }}

--- a/{{ cookiecutter.project_slug }}/docker-compose.override.no-build.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.override.no-build.yml
@@ -1,0 +1,7 @@
+version: '3'
+services:
+  django:
+    image: ghcr.io/{{ cookiecutter.github_repo }}/django:main
+
+  celery:
+    image: ghcr.io/{{ cookiecutter.github_repo }}/django:main


### PR DESCRIPTION
Note this is based on #172

For many projects, it can be useful to have pre-built images that can be quickly pulled down to spin up a project. 

For example, if the UI/UX team is helping fix a bug or implement new front-end code, having prebuilt images that can spin up the application using the override included in `{{ cookiecutter.project_slug }}/docker-compose.override.no-build.yml` as:

```
docker compose -f docker-compose.yml -f docker-compose.override.yml -f docker-compose.override.no-build.yml up
```

Will make it much faster/easier for external collaborators to spin up the application.

An additional use case is when there is a VueJS based front-end application that has a different development team than the backend Girder4 project - in these scenarios, it will also be helpful for that team to be able to pull the latest pre-built images as needed rather than building themselves.