### PR TITLE
Remove unnecessary namespace for Django OAuth Toolkit URLs

### DIFF
--- a/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/urls.py
+++ b/{{ cookiecutter.project_slug }}/{{ cookiecutter.pkg_name }}/urls.py
@@ -26,7 +26,7 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path('accounts/', include('allauth.urls')),
-    path('oauth/', include('oauth2_provider.urls', namespace='oauth2_provider')),
+    path('oauth/', include('oauth2_provider.urls')),
     path('admin/', admin.site.urls),
     path('api/v1/s3-upload/', include('s3_file_field.urls')),
     path('api/v1/', include(router.urls)),


### PR DESCRIPTION
An explicit instance namespace is not necessary. From the Django docs:
> If the instance namespace is not specified,
> it will default to the included URLconf’s application namespace.

In Django OAuth Toolkit, the application namespace is already "oauth2_provider".