### PR TITLE
Update docker-compose.yml

### DIFF
--- a/{{ cookiecutter.project_slug }}/README.md
+++ b/{{ cookiecutter.project_slug }}/README.md
@@ -44,6 +44,7 @@ but allows developers to run Python code on their native system.
    1. `source ./dev/export-env.sh`
    2. `celery --app {{ cookiecutter.pkg_name }}.celery worker --loglevel INFO --without-heartbeat`
 4. When finished, run `docker-compose stop`
+5. To destroy the stack and start fresh, run `docker-compose down -v`
 
 ## Remap Service Ports (optional)
 Attached services may be exposed to the host system via alternative ports. Developers who work

--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -15,6 +15,8 @@ services:
     ports:
       - ${DOCKER_RABBITMQ_PORT-5672}:5672
       - ${DOCKER_RABBITMQ_CONSOLE_PORT-15672}:15672
+    volumes:
+      - rabbitmq:/var/lib/rabbitmq/mnesia
 
   minio:
     image: minio/minio:latest
@@ -33,3 +35,4 @@ services:
 volumes:
   postgres:
   minio:
+  rabbitmq:

--- a/{{ cookiecutter.project_slug }}/docker-compose.yml
+++ b/{{ cookiecutter.project_slug }}/docker-compose.yml
@@ -7,6 +7,8 @@ services:
       POSTGRES_PASSWORD: postgres
     ports:
       - ${DOCKER_POSTGRES_PORT-5432}:5432
+    volumes:
+      - postgres:/var/lib/postgresql/data
 
   rabbitmq:
     image: rabbitmq:management
@@ -25,3 +27,9 @@ services:
     ports:
       - ${DOCKER_MINIO_PORT-9000}:9000
       - ${DOCKER_MINIO_CONSOLE_PORT-9001}:9001
+    volumes:
+      - minio:/data
+
+volumes:
+  postgres:
+  minio:


### PR DESCRIPTION
Allow users of this cookiecutter to choose whether they use `docker-compose down` or `docker-compose stop` based on their individual needs without losing their database and files.

@zachmullen asked me to make this change a while ago, but I never got around to it.