### PR TITLE
Disable nightly CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - master
-  schedule:
-    - cron: "0 0 * * *"
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
For active projects, nightly CI tends to be superfluous.
For inactive projects, nightly CI causes all CI to be disabled after 60 days:
https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#disabling-and-enabling-workflows