### PR TITLE
Add timeout for gunicorn

### DIFF
--- a/{{ cookiecutter.project_slug }}/Procfile
+++ b/{{ cookiecutter.project_slug }}/Procfile
@@ -1,3 +1,3 @@
 release: ./manage.py migrate
-web: gunicorn --bind 0.0.0.0:$PORT {{ cookiecutter.pkg_name }}.wsgi
+web: gunicorn --bind 0.0.0.0:$PORT {{ cookiecutter.pkg_name }}.wsgi --timeout 25
 worker: REMAP_SIGTERM=SIGQUIT celery --app {{ cookiecutter.pkg_name }}.celery worker --loglevel INFO --without-heartbeat


### PR DESCRIPTION
See https://devcenter.heroku.com/articles/request-timeout#timeout-behavior for rationale.

In particular, gunicorn throws a generic `SystemExit` when a timeout occurs from Heroku. I believe this will instead raise something like a `WorkerTimeoutError`, but I haven't tested it yet.